### PR TITLE
Add `UnknownFieldHandler`

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1703,6 +1703,7 @@ func (s *S) TestUnmarshalKnownFields(c *C) {
 		t := reflect.ValueOf(item.value).Type()
 		value := reflect.New(t)
 		dec := yaml.NewDecoder(bytes.NewBuffer([]byte(item.data)))
+		//goland:noinspection GoDeprecation
 		dec.KnownFields(item.known)
 		err := dec.Decode(value.Interface())
 		c.Assert(err, ErrorMatches, item.error)


### PR DESCRIPTION
Before we have to live with always break on unknown fields or not, using:
```golang
dec := yaml.NewDecoder(f)
dec.KnownFields(true)
```

With this change we can define a custom function, like:
```golang
dec := yaml.NewDecoder(f)
dec.OnUnknownField(func(node *Node, name reflect.Value, out reflect.Value) error {
   // Do our stuff...
})
```
Additionally, this can be also changed for `yaml.Node`, like:

```golang
func main() {
  var mt myType
  dec := yaml.NewDecoder(f)
  dec.OnUnknownField(func(node *Node, name reflect.Value, out reflect.Value) error {
     // Do our stuff...
  })
  dec.Decode(&mt)
}

func (m *myType) UnmarshalYAML(value *yaml.Node) error {
    value.OnUnknownField(func(node *Node, name reflect.Value, out reflect.Value) error {
       // Do other stuff...
    }) 
    value.Decode(...)
}
```

